### PR TITLE
Make flydowns use the same renderer as the target workspace

### DIFF
--- a/block-lexical-variables/src/index.js
+++ b/block-lexical-variables/src/index.js
@@ -49,7 +49,13 @@ export function init(workspace) {
   // TODO: Might need the next line
   // Blockly.DropDownDiv.createDom();
   const flydown = new Flydown(
-      new Blockly.Options({scrollbars: false}));
+      new Blockly.Options({
+        scrollbars: false,
+        rtl: workspace.RTL,
+        renderer: workspace.options.renderer,
+        rendererOverrides: workspace.options.rendererOverrides,
+      })
+  );
   // ***** [lyn, 10/05/2013] NEED TO WORRY ABOUT MULTIPLE BLOCKLIES! *****
   workspace.flydown_ = flydown;
   Blockly.utils.dom.insertAfter(flydown.createDom('g'),


### PR DESCRIPTION
Before:
![flydown before](https://user-images.githubusercontent.com/46355725/224441047-0726c31c-09b0-4648-bca3-a0b565c8f02e.png)

After:
![flydown after](https://user-images.githubusercontent.com/46355725/224440796-a3da0b31-10fd-42cf-bca8-71c8e068bcab.png)

Related to issue #27.