### PR TITLE
Fix events UI is not a constructor

### DIFF
--- a/block-lexical-variables/src/blocks/procedures.js
+++ b/block-lexical-variables/src/blocks/procedures.js
@@ -357,10 +357,9 @@ Blockly.Blocks['procedures_defnoreturn'] = {
       this.horizontalParameters = isHorizontal;
       this.updateParams_();
       if (Blockly.Events.isEnabled()) {
-        // Trigger a Blockly UI change event
-        Blockly.Events.fire(new Blockly.Events.Ui(this, 'parameter_orientation',
-            (!this.horizontalParameters).toString(),
-            this.horizontalParameters.toString()));
+        Blockly.Events.fire(new Blockly.Events.BlockChange(this, 'parameter_orientation', null,
+            !this.horizontalParameters,
+            this.horizontalParameters));
       }
     }
   },


### PR DESCRIPTION
To reproduce  error pull a function block out, add some inputs and then right click to toggle between horizontal & vertical parameters.