### PR TITLE
Fix add second variable in local_declaration_statement block

### DIFF
--- a/block-lexical-variables/src/blocks/lexical-variables.js
+++ b/block-lexical-variables/src/blocks/lexical-variables.js
@@ -286,7 +286,6 @@ Blockly.Blocks['local_declaration_statement'] = {
     this.rendered = false;
 
     // Save current body connection, then remove the body input cleanly.
-    console.log(`BodyInputName: ${this.bodyInputName}`)
     const oldBody = this.getInput(this.bodyInputName);
     const oldBodyConn =
       oldBody && oldBody.connection && oldBody.connection.targetConnection;

--- a/block-lexical-variables/src/blocks/lexical-variables.js
+++ b/block-lexical-variables/src/blocks/lexical-variables.js
@@ -286,6 +286,7 @@ Blockly.Blocks['local_declaration_statement'] = {
     this.rendered = false;
 
     // Save current body connection, then remove the body input cleanly.
+    console.log(`BodyInputName: ${this.bodyInputName}`)
     const oldBody = this.getInput(this.bodyInputName);
     const oldBodyConn =
       oldBody && oldBody.connection && oldBody.connection.targetConnection;
@@ -335,8 +336,15 @@ Blockly.Blocks['local_declaration_statement'] = {
     }
 
     // Recreate the body input and reconnect the body if it existed.
-    const bodyInput = this.appendStatementInput(this.bodyInputName)
-      .appendField(Blockly.Msg.LANG_VARIABLES_LOCAL_DECLARATION_IN_DO);
+    let bodyInput
+    if (this.type === 'local_declaration_expression') {
+      bodyInput = this.appendInputFromRegistry('indented_input', this.bodyInputName)
+        .appendField(
+          Blockly.Msg.LANG_VARIABLES_LOCAL_DECLARATION_EXPRESSION_IN_RETURN);
+    } else {
+      bodyInput = this.appendStatementInput(this.bodyInputName)
+        .appendField(Blockly.Msg.LANG_VARIABLES_LOCAL_DECLARATION_IN_DO);
+    }
     if (savedRendered && bodyInput.init) bodyInput.init();
     if (oldBodyConn) {
       bodyInput.connection.connect(oldBodyConn);

--- a/block-lexical-variables/src/warningHandler.js
+++ b/block-lexical-variables/src/warningHandler.js
@@ -73,10 +73,8 @@ export default class WarningHandler {
       }
     }
 
-    // remove the warning icon, if there is one
-    if (block.warning) {
-      block.setWarningText(null);
-    }
+    // remove the warning icon
+    block.setWarningText(null);
     if (block.hasWarning) {
       block.hasWarning = false;
     }

--- a/block-lexical-variables/src/warningHandler.js
+++ b/block-lexical-variables/src/warningHandler.js
@@ -73,8 +73,10 @@ export default class WarningHandler {
       }
     }
 
-    // remove the warning icon
-    block.setWarningText(null);
+    // remove the warning icon, if there is one
+    if (block.warning) {
+      block.setWarningText(null);
+    }
     if (block.hasWarning) {
       block.hasWarning = false;
     }


### PR DESCRIPTION
Fix for the issue that occurs when adding a second variable to the `local_declaration_statement` starting with Blockly V11, which was discussed in #68.