### PR TITLE
Remove block.warning check since the property has been removed

### DIFF
--- a/block-lexical-variables/src/warningHandler.js
+++ b/block-lexical-variables/src/warningHandler.js
@@ -73,10 +73,8 @@ export default class WarningHandler {
       }
     }
 
-    // remove the warning icon, if there is one
-    if (block.warning) {
-      block.setWarningText(null);
-    }
+    // remove the warning icon
+    block.setWarningText(null);
     if (block.hasWarning) {
       block.hasWarning = false;
     }


### PR DESCRIPTION
Fix bug mentioned [this message](https://github.com/mit-cml/blockly-plugins/pull/76#issuecomment-3227147906) in #76 

[Screencast from 2025-08-27 09-40-04.webm](https://github.com/user-attachments/assets/348a84af-29c6-4f4a-9c3f-17e36fcc10f4)