### PR TITLE
Support getGlobalNames call before workspace is initialized

### DIFF
--- a/block-lexical-variables/src/fields/field_lexical_variable.js
+++ b/block-lexical-variables/src/fields/field_lexical_variable.js
@@ -159,6 +159,8 @@ FieldLexicalVariable.prototype.setBlock = function(block) {
 FieldLexicalVariable.getGlobalNames = function(optExcludedBlock) {
   // TODO: Maybe switch to injectable warning/error handling
   const mainWorkspace = Blockly.common.getMainWorkspace();
+  // Return when the workspace is not initialized yet (e.g. toolbox-search plugin)
+  if (!mainWorkspace) return []
   const rootWorkspace = mainWorkspace.getRootWorkspace() || mainWorkspace;
   if (Instrument.useLynCacheGlobalNames && rootWorkspace &&
       rootWorkspace.getWarningHandler &&


### PR DESCRIPTION
This PR adds a null check for `mainWorkspace` in `getGlobalNames`, fixing errors with `@blockly/toolbox-search`, which can invoke the function before the workspace is initialized.

Resolves #73 