### PR TITLE
Remove duplicate AUTOHIDEABLE capability registration in Flydown

### DIFF
--- a/block-lexical-variables/src/fields/flydown.js
+++ b/block-lexical-variables/src/fields/flydown.js
@@ -84,10 +84,10 @@ Flydown.prototype.setCSSClass = function(newCSSClassName) {
  */
 Flydown.prototype.init = function(workspace) {
   // Flydowns have no scrollbar
+  // Note: Flyout.prototype.init already registers AUTOHIDEABLE capability
+  // via addComponent, so we do not need to call addCapability again.
   Blockly.Flyout.prototype.init.call(this, workspace, false);
   this.workspace_.setTheme(workspace.getTheme());
-  workspace.getComponentManager().addCapability(this.id,
-      Blockly.ComponentManager.Capability.AUTOHIDEABLE);
 };
 
 /**


### PR DESCRIPTION
## Summary
Remove redundant `addCapability(AUTOHIDEABLE)` call in `Flydown.prototype.init`. `Flyout.prototype.init` already registers this capability via `addComponent`, so the second call is unnecessary and can trigger a warning.

## Context
`Flyout.prototype.init` registers `AUTOHIDEABLE` (along with `DELETE_AREA` and `DRAG_TARGET`) through [`addComponent`](https://github.com/google/blockly/blob/blockly-v11.2.2/core/flyout_base.ts#L429-L436), so the explicit `addCapability` call in `Flydown.prototype.init` is redundant.

## Test plan
- [x] All existing unit tests pass
- [x] Manual verification: flydown panels function correctly